### PR TITLE
updated vcf script to combine identical CN states

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ out
 err
 run2.sh
 run.sh
+scripts/tests*
 
 # Byte-compiled / optimized / DLL files
 __pycache__/


### PR DESCRIPTION
The new script combines identical CN states across clones to prevent them from overwriting one another within decifer